### PR TITLE
Bug/conflict gestures

### DIFF
--- a/lib/src/rendering/render_timeline_item.dart
+++ b/lib/src/rendering/render_timeline_item.dart
@@ -225,19 +225,23 @@ class RenderTimelineItem extends RenderProxyBox
       if (_axis == Axis.vertical) {
         _topDragGestureRecognizer = VerticalDragGestureRecognizer()
           ..onUpdate = _onUpdateTopOrLeft
-          ..onEnd = _onEndTopOrLeft;
+          ..onEnd = _onEndTopOrLeft
+          ..dragStartBehavior = DragStartBehavior.down;
 
         _bottomDragGestureRecognizer = VerticalDragGestureRecognizer()
           ..onUpdate = _onUpdateBottomOrRight
-          ..onEnd = _onEndBottomOrLeft;
+          ..onEnd = _onEndBottomOrLeft
+          ..dragStartBehavior = DragStartBehavior.down;
       } else {
         _leftDragGestureRecognizer = HorizontalDragGestureRecognizer()
           ..onUpdate = _onUpdateTopOrLeft
-          ..onEnd = _onEndTopOrLeft;
+          ..onEnd = _onEndTopOrLeft
+          ..dragStartBehavior = DragStartBehavior.down;
 
         _rightDragGestureRecognizer = HorizontalDragGestureRecognizer()
           ..onUpdate = _onUpdateBottomOrRight
-          ..onEnd = _onEndBottomOrLeft;
+          ..onEnd = _onEndBottomOrLeft
+          ..dragStartBehavior = DragStartBehavior.down;
       }
     }
   }

--- a/test/widgets/timeline_item_test.dart
+++ b/test/widgets/timeline_item_test.dart
@@ -35,8 +35,11 @@ void main() {
             onEndDateTimeChanged: onEndDateTimeChanged,
             onStartDateTimeUpdated: onStartDateTimeUpdated,
             onEndDateTimeUpdated: onEndDateTimeUpdated,
-            child: Container(
-              color: Colors.red,
+            child: GestureDetector(
+              onTap: () {},
+              child: Container(
+                color: Colors.red,
+              ),
             ),
           ),
         ],


### PR DESCRIPTION
## Description

When the child of the TimelineItem detects other gestures such as onTap, the first move wasn't detected so all the tests fail.
The problem was solved by changing the dragStartBehavior from start to down.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore